### PR TITLE
chore: resolve Dependabot security alerts (brace-expansion) - 2026-07-21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1170,9 +1170,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -1568,9 +1568,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3930,9 +3930,9 @@
       }
     },
     "node_modules/react-scanner/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"

--- a/package.json
+++ b/package.json
@@ -78,5 +78,10 @@
   },
   "engines": {
     "node": ">= 24.14.1"
+  },
+  "overrides": {
+    "react-scanner": {
+      "picomatch": "^2.3.2"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Two fixes, both lockfile/override-scoped, taking **components-stats to 0 npm-audit vulnerabilities**:

1. **brace-expansion** (GHSA-3jxr-9vmj-r5cp, ReDoS, high) — bumped 1.1.13→1.1.16 and 2.0.3→2.1.2 via `npm audit fix`.
2. **picomatch** (method injection in POSIX classes + extglob ReDoS, high; `<2.3.2`) — the vulnerable `picomatch@2.3.1` comes via `react-scanner@1.2.0` (already the latest release, so `npm audit fix` reported no fix). Added a scoped override `react-scanner > picomatch: ^2.3.2` (resolves 2.3.2). This also clears the **react-scanner** moderate, which was flagged only through the vulnerable picomatch.

## Audit delta

| Severity | Before | After |
|---|---|---|
| high | 2 | 0 |
| moderate | 1 | 0 |
| **total** | **3** | **0** |

## Jira (Fixed)
- [UXP-3323](https://jimplan.atlassian.net/browse/UXP-3323) — alert 62 (brace-expansion high)
- [UXP-3324](https://jimplan.atlassian.net/browse/UXP-3324) — alert 63 (brace-expansion high)

## Verification
- `npm run typecheck` — passed
- `npm run build` — passed
- `npm test` — passed
- `npm ci` — passes (lockfile ↔ package.json consistent)
- `npm audit` — **0 vulnerabilities**

[UXP-3323]: https://jimplan.atlassian.net/browse/UXP-3323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[UXP-3324]: https://jimplan.atlassian.net/browse/UXP-3324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ