### PR TITLE
chore: resolve Dependabot security alerts - 2026-08-05

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1562,9 +1562,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
## Summary
- Bump **brace-expansion** to a patched in-range version via `npm update brace-expansion` (new advisory GHSA-mh99-v99m-4gvg follow-up: vulnerable `4.0.0 - 5.0.8`, patched **5.0.9**). The vulnerable copy was the top-level `node_modules/brace-expansion` (not bundled), so a plain update resolves it. Lockfile-only.

## Audit delta
| Severity | Before | After |
|---|---|---|
| High | 1 | **0** |
| **Total** | **1** | **0** |

## Verification
- `npm run typecheck` — exit 0
- `npm run check` (biome) — exit 0
- `npm test` — 3 passed
- `npm run build` — exit 0
- `npm audit` — 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)