### PR TITLE
chore: resolve Dependabot security alerts - 2026-08-07

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3568,9 +3568,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

Resolves the Dependabot high-severity alert for **nanoid** — an infinite-loop DoS when custom generators are called with `size = 0` ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8), CWE-835). nanoid is a transitive dependency (`vitest > vite > postcss > nanoid`). Bumped within the 3.x line via `npm update nanoid`; no override needed. Change is lockfile-only.

## Audit delta

| | Before | After |
|---|---|---|
| nanoid | 3.3.16 | 3.3.18 |
| high vulnerabilities | 1 | 0 |
| total vulnerabilities | 1 | 0 |

`npm audit` before: 1 high (nanoid `<3.3.17`). After: `found 0 vulnerabilities`.

## Verification

- `npm audit` → 0 vulnerabilities
- `npm run typecheck` → pass
- `npm run check` (biome) → pass (one unrelated auto-format reverted to keep diff lockfile-only)
- `npm test` → 3/3 pass
- `npm run build` → pass

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with Claude Code