### PR TITLE
chore: tighten stale brace-expansion override - 2026-08-13

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
     "react-scanner": {
       "picomatch": "^2.3.2"
     },
-    "brace-expansion": "^5.0.8"
+    "brace-expansion": "^5.0.9"
   }
 }


### PR DESCRIPTION
## What

Tighten the `brace-expansion` entry in `package.json` `overrides`:

```diff
-    "brace-expansion": "^5.0.8"
+    "brace-expansion": "^5.0.9"
```

## Why

The `^5.0.8` caret still admitted the advisory-vulnerable `5.0.8`. **GHSA-rgw5-rvv9-x895** covers `<5.0.9`, so raising the override floor to `^5.0.9` closes that window and prevents a future resolve from pulling `5.0.8` back in.

## Verification

- `npm ls brace-expansion --all` shows every resolution at `5.0.9`.
- `npm audit` total **unchanged**: 0 vulnerabilities before → 0 after (did not increase).
- Gates all pass: `typecheck`, `check` (biome), `test`, `build`, plus husky pre-commit. Biome auto-formatted an unrelated file (`src/react-scanner.d.ts`) during `check`; it was reverted so the diff stays `package.json` only.
- The `react-scanner>picomatch` override is left untouched.
- Lockfile already resolved to `5.0.9`, so no `package-lock.json` change was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)