### PR TITLE
chore: add CODEOWNERS assigning @Jimdo/uxp-devs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Jimdo/uxp-devs


### PR DESCRIPTION
This repo has no CODEOWNERS file, so PRs get no automatic team reviewer.

Add one that matches the rest of the UXP repos:

```
* @Jimdo/uxp-devs
```

Every path now requests a review from @Jimdo/uxp-devs, the same setup used in ia, logger, maverick, and the other UXP packages.