### PR TITLE
ci: add Dependabot auto-merge for minor and patch bumps

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,31 @@
+name: Dependabot auto-merge
+on:
+  pull_request:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: jimdo-runner-1core
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Approve the PR
+        if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}


### PR DESCRIPTION
Add Dependabot auto-merge, mirroring the setup in `Jimdo/ui`.

When Dependabot opens a **minor** or **patch** PR, this workflow approves it and enables auto-merge. GitHub then merges once required checks pass. **Major** bumps are left for a human.

Two things must be in place for this to merge on its own — tracked separately, not in this PR:

1. Branch protection on the default branch: require the CI check + one approving review.
2. The `DEPENDABOT_AUTOMERGE_TOKEN` org secret scoped to this repo (the merge step runs on it so the release pipeline still fires; a merge by the default token would not re-trigger it).

Until both land, Dependabot PRs still get approved and CI-gated — they just need a human to click merge.