### PR TITLE
ci: group related Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,14 @@ updates:
       include: 'scope'
     cooldown:
       default-days: 3
+    groups:
+      vitest:
+        patterns:
+          - 'vitest'
+          - '@vitest/*'
+      commitizen:
+        patterns:
+          - '@ryansonshine/*'
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Batches related dependency bumps into one PR each, so packages that release together stop opening a PR apiece.

Added groups: vitest, commitizen.

Existing groups, comments, and ignore rules are unchanged. Derived from the packages this repo actually depends on.
